### PR TITLE
Refer android libraries correctly

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,9 +23,8 @@
         <source-file src="src/android/TensorFlow.java" target-dir="src/io/wq/tensorflow" />
         <source-file src="src/android/tf_libs/Classifier.java" target-dir="src/org/tensorflow/demo" />
         <source-file src="src/android/tf_libs/TensorFlowImageClassifier.java" target-dir="src/org/tensorflow/demo" />
-        <source-file src="src/android/tf_libs/libandroid_tensorflow_inference_java.jar" target-dir="libs" />
-        <source-file src="src/android/tf_libs/armeabi-v7a/libtensorflow_inference.so" target-dir="libs/armeabi" />
-
+        <lib-file src="src/android/tf_libs/libandroid_tensorflow_inference_java.jar" />
+        <resource-file src="src/android/tf_libs/armeabi-v7a/libtensorflow_inference.so" target="jniLibs/armeabi-v7a/libtensorflow_inference.so" />
     </platform>
 
     <platform name="ios">


### PR DESCRIPTION
.jar files should be referred with the lib-file tag as suggested in the [docs](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#lib-file)
.so files should be included in `jniLibs` directory inside `platforms/android/app/src/main`. Else they are not included and will not work.

### Why propose this change?
Installing this plugin places both the `.jar` and the `.so` dependency files inside `platforms/android/libs/` directory. This confuses cordova into thinking that the project's structure is actually an old eclise project and causes subsequent plugin installations to act accordingly and look for `AndroidManifest.xml` (and other configuration files) in the wrong place. This results in errors like:
```
Failed to install 'cordova-plugin-whitelist': Error: ENOENT: no such file or directory, open 'D:\Testing\masterTest\platforms\android\AndroidManifest.xml'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.readFileSync (fs.js:508:33)
    at Object.parseElementtreeSync (D:\Testing\masterTest\platforms\android\cordova\node_modules\cordova-common\src\util\xml-helpers.js:180:27)
    at new AndroidManifest (D:\Testing\masterTest\platforms\android\cordova\lib\AndroidManifest.js:29:20)
    at AndroidProject.getPackageName (D:\Testing\masterTest\platforms\android\cordova\lib\AndroidProject.js:99:12)
    at Api.addPlugin (D:\Testing\masterTest\platforms\android\cordova\Api.js:223:57)
    at handleInstall (C:\Users\kerezov\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js:594:10)
    at C:\Users\kerezov\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js:357:28
    at _fulfilled (C:\Users\kerezov\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\node_modules\q\q.js:787:54)
Failed to restore plugin "cordova-plugin-whitelist" from config.xml. You might need to try adding it again. Error: Error: ENOENT: no such file or directory, open 'D:\Testing\masterTest\platforms\android\AndroidManifest.xml'
--save flag or autosave detected
```` 

### Why aren't both files referenced as `lib-file`?
The `.so` file isn't properly included in the result `.apk` if it is referenced as a `lib-file`. Even if the `arch="device"` tag is specified as suggested in the [docs](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#lib-file), the `.so` file still ends up in `libs` directory rather than `jniLibs`

### Why reference the `.so` as a `resource-file` instead of a `source-file`?
In case the `.so` is referenced as a `source-file` it ends up in the root of `platforms/android` - namely at `platforms/android/jniLibs/armeabi-v7a/libtensorflow_inference.so`.
What we actually want is for it to end up at `platforms/android/app/src/main/jniLibs/armeabi-v7a/libtensorflow_inference.so` in order for it to end up properly in the built `.apk`.

### Further improvement
This `.so` library can actually be included inside a `.jar` and referenced as a `lib-file`. This is the way to move forward I think because that would alleviate cordova of trying to place the file in the correct directory and let the `gradle` build system handle it. 
An example of this can be seen in this [sqlite plugin](https://github.com/litehelpers/Cordova-sqlite-storage/blob/storage-master/plugin.xml#L39)

The above has all been tested with `cordova` cli version `8.0.0` and `cordova-android@~7.0.0`
Ping @sheppard for thoughts about this